### PR TITLE
chore: añadir .kiro/ a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+.claude/
+GEMINI.md
+.kiro/


### PR DESCRIPTION
Kiro CLI lee contexto vía .kiro/steering/context.md (symlink gestionado por myClaudeContext), igual que GEMINI.md. Se excluye del repo.